### PR TITLE
Throw an exception if we fail to find strings.xml.

### DIFF
--- a/src/io/appium/apktools/StringsXML.java
+++ b/src/io/appium/apktools/StringsXML.java
@@ -100,6 +100,10 @@ public class StringsXML {
       }
     }
 
+    if (stringsXML == null) {
+      e("Could not find the strings.xml file for localization: " + localization);
+    }
+
     toJSON(stringsXML, outputDirectory);
     p("complete");
   }


### PR DESCRIPTION
Just a simple null check to get a more meaningful message in case we cannot find the strings.xml file (e.g. when an invalid/non-existent language is requested). Otherwise, we'll get a NullPointerException on line 39.
